### PR TITLE
Update RI.yaml

### DIFF
--- a/configs/bi/RI.yaml
+++ b/configs/bi/RI.yaml
@@ -12,7 +12,3 @@ links:
 - name: secondary
   url: https://datastudio.google.com/u/0/reporting/d8e4680b-7cf1-4a70-860b-7bbf5e0bf9a2/page/D0DYC
   message: alternative view of breakthrough infections data in case the dash (secondary) does not load
-
-- name: tertiary
-  url: https://datastudio.google.com/u/0/reporting/a0d242bf-a367-47cd-b9b7-1add9f2c475c/page/MsaWC
-  message: alternative view of breakthrough cases data in case the dash (secondary) does not load


### PR DESCRIPTION
this dashboard view says retired on top, and shows half the number of the other one. I think we should remove

![image](https://user-images.githubusercontent.com/1749380/139277590-525b3a08-bc4e-4389-94db-396ee559e50e.png)
